### PR TITLE
Re-root CLI under `vekna tmux` (0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@ and this project adheres to [Semantic Versioning].
 ### Security
 
 
+## [0.1.0] - 2026-06-01
+
+### Changed
+
+- **CLI re-rooted under `vekna tmux`.** Existing behaviour moved one level
+  deeper to free the top-level `vekna` command for the upcoming rituals
+  overseer. Bare `vekna` now prints help listing available command groups.
+  - `vekna` (attach) → `vekna tmux`
+  - `vekna daemon` → `vekna tmux daemon`
+  - `vekna notify …` → `vekna tmux notify …`
+  - `vekna status-bar` → `vekna tmux status-bar`
+- Bundled `tmux.conf` updated to call `vekna tmux status-bar` in its
+  `status-right` line.
+- Claude Code notification hook is now
+  `vekna tmux notify --app claude --hook Notification`.
+
+
 ## [0.0.4] - 2026-04-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
 # Vekna
 
 Vekna watches a tmux session full of running Claude Code instances and
-switches focus to whichever pane needs attention. The `vekna` command
+switches focus to whichever pane needs attention. The `vekna tmux` command
 starts a server that attaches the session and listens on a Unix socket;
-`vekna notify`, run from inside a pane, asks the server to select that
+`vekna tmux notify`, run from inside a pane, asks the server to select that
 pane so the user lands on the agent that wants them.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vekna
 
 Overseer for multiple Claude Code (or any coding agent) instances running in
-tmux. One agent calls `vekna notify` → tmux jumps to its pane.
+tmux. One agent calls `vekna tmux notify` → tmux jumps to its pane.
 
 ## Requires
 
@@ -18,22 +18,22 @@ pip install .
 
 ### Starting a project session
 
-Run `vekna` from any project directory:
+Run `vekna tmux` from any project directory:
 
 ```bash
 cd ~/projects/myapp
-vekna
+vekna tmux
 ```
 
 This starts a background daemon (if not already running) and attaches you
 to a dedicated tmux session for that directory (`vekna-myapp-<hash>`). Open
 windows with `Ctrl-b c` and run a coding agent in each.
 
-Run `vekna` from a second project in another terminal:
+Run `vekna tmux` from a second project in another terminal:
 
 ```bash
 cd ~/projects/api
-vekna
+vekna tmux
 ```
 
 Both sessions share a single daemon — one socket, one process, all projects.
@@ -44,16 +44,16 @@ Both sessions share a single daemon — one socket, one process, all projects.
 |------|--------|
 | `Ctrl-b s` | Interactive session picker (all vekna sessions listed) |
 | `Ctrl-b )` / `Ctrl-b (` | Next / previous session |
-| `Ctrl-b d` | Detach — return to the terminal you launched `vekna` from |
+| `Ctrl-b d` | Detach — return to the terminal you launched `vekna tmux` from |
 
-After detaching, run `vekna` again from the same directory to reattach.
+After detaching, run `vekna tmux` again from the same directory to reattach.
 
 ### Claude Code configuration
 
 Add a notification hook in Claude Code settings:
 
 ```
-echo "$CLAUDE_HOOK_DATA" | vekna notify --app claude --hook Notification
+echo "$CLAUDE_HOOK_DATA" | vekna tmux notify --app claude --hook Notification
 ```
 
 `--app` and `--hook` are required. The payload is read from stdin and the
@@ -65,7 +65,7 @@ To show pending notification counts across all sessions, add this to your
 `~/.tmux.conf`:
 
 ```
-set -g status-right '#(vekna status-bar)'
+set -g status-right '#(vekna tmux status-bar)'
 ```
 
 > **Note:** tmux runs status bar commands with a limited `PATH`. If `vekna`
@@ -73,30 +73,31 @@ set -g status-right '#(vekna status-bar)'
 > path instead:
 >
 > ```
-> set -g status-right '#(/path/to/vekna status-bar)'
+> set -g status-right '#(/path/to/vekna tmux status-bar)'
 > ```
 >
 > Find the path with `which vekna`. To install globally, use
 > `pipx install .` from the repo root.
 
 Output looks like `myapp(2) api(1)` when agents in those sessions are
-waiting. The count resets when you run `vekna` from that directory again
-(i.e. when you attach to the session).
+waiting. The count resets when you run `vekna tmux` from that directory
+again (i.e. when you attach to the session).
 
 ### Commands
 
 | Command | Effect |
 |---------|--------|
-| `vekna` | Ensure daemon running, create session for current directory, attach |
-| `vekna daemon` | Start the daemon explicitly (blocks; use for init systems or debugging) |
-| `vekna notify --app <app> --hook <hook>` | Send a notification from the current pane; payload from stdin, pane from `$TMUX_PANE` |
-| `vekna status-bar` | Print pending notification summary (empty if daemon not running) |
+| `vekna` | Print help listing available command groups |
+| `vekna tmux` | Ensure daemon running, create session for current directory, attach |
+| `vekna tmux daemon` | Start the daemon explicitly (blocks; use for init systems or debugging) |
+| `vekna tmux notify --app <app> --hook <hook>` | Send a notification from the current pane; payload from stdin, pane from `$TMUX_PANE` |
+| `vekna tmux status-bar` | Print pending notification summary (empty if daemon not running) |
 
 ## How it works
 
 ```mermaid
 flowchart TD
-    A["agent pane\necho $CLAUDE_HOOK_DATA | vekna notify --app claude --hook Notification"]
+    A["agent pane\necho $CLAUDE_HOOK_DATA | vekna tmux notify --app claude --hook Notification"]
     B["/tmp/vekna-&lt;uid&gt;.sock"]
     C[ServerMill\ndaemon]
     D[EventBus]
@@ -112,13 +113,14 @@ flowchart TD
     E -->|"publish(vekna, SelectPane)"| H
 ```
 
-- One daemon owns `/tmp/vekna-<uid>.sock` and manages all sessions. `vekna`
-  starts it automatically on first use via `os.fork()`.
-- `vekna` sends an `EnsureSession{cwd}` request to the daemon, receives back
-  the session name, and calls `tmux attach-session` to hand control to tmux.
-- `vekna notify` sends a `(claude, Notification)` event to the daemon socket.
-  The daemon increments the pending count for that session and publishes the
-  event to the `EventBus`.
+- One daemon owns `/tmp/vekna-<uid>.sock` and manages all sessions.
+  `vekna tmux` starts it automatically on first use via `os.fork()`.
+- `vekna tmux` sends an `EnsureSession{cwd}` request to the daemon, receives
+  back the session name, and calls `tmux attach-session` to hand control to
+  tmux.
+- `vekna tmux notify` sends a `(claude, Notification)` event to the daemon
+  socket. The daemon increments the pending count for that session and
+  publishes the event to the `EventBus`.
 - **ClaudeNotificationHandler** validates the payload and re-publishes a
   `(vekna, SelectPane)` event carrying the pane ID.
 - **SelectPaneHandler** handles `SelectPane`:
@@ -126,7 +128,7 @@ flowchart TD
     to jump to the notifying pane immediately.
   - Otherwise, highlights the notifying window red. A background loop
     (`clear_marks_loop`) clears the mark once the user navigates to it.
-- `vekna status-bar` sends a `(vekna, StatusBar)` request; the daemon
+- `vekna tmux status-bar` sends a `(vekna, StatusBar)` request; the daemon
   responds with a formatted summary of all sessions with pending counts.
 
 Session naming (`vekna-<basename>-<hash>`) lives in `src/vekna/specs/constants.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vekna"
-version = "0.0.4"
+version = "0.1.0"
 description = "Coding agent overseer"
 authors = [{ name = "Radosław Ganczarek", email = "radoslaw@ganczarek.in" }]
 license = { text = "BSD-3-Clause license" }

--- a/src/vekna/conf/tmux.conf
+++ b/src/vekna/conf/tmux.conf
@@ -60,7 +60,7 @@ set -g status-left-length 40
 set -g status-left "#[fg=colour39,bold] #S #[fg=colour235,bg=colour235] "
 
 set -g status-right-length 60
-set -g status-right "#(vekna status-bar --session #{session_name})  #[fg=colour239]%H:%M "
+set -g status-right "#(vekna tmux status-bar --session #{session_name})  #[fg=colour239]%H:%M "
 
 setw -g window-status-format         "#[fg=colour245] #I:#W "
 setw -g window-status-current-format "#[fg=colour255,bg=colour238,bold] #I:#W "

--- a/src/vekna/gates/cli/click/command.py
+++ b/src/vekna/gates/cli/click/command.py
@@ -13,7 +13,7 @@ from vekna.pacts.notify import Event, NotifyClientMillProtocol
 from vekna.pacts.server import ServerMillProtocol
 
 _MISSING_TMUX_PANE_MSG = (
-    "TMUX_PANE must be set — run `vekna notify` from inside a tmux pane"
+    "TMUX_PANE must be set — run `vekna tmux notify` from inside a tmux pane"
 )
 
 
@@ -31,6 +31,12 @@ class ClickGate:
     def build_group(self) -> click.Group:
         @click.group(invoke_without_command=True)
         def vekna() -> None:
+            ctx = click.get_current_context()
+            if ctx.invoked_subcommand is None:
+                click.echo(ctx.get_help())
+
+        @click.group(invoke_without_command=True)
+        def tmux() -> None:
             ctx = click.get_current_context()
             if ctx.invoked_subcommand is None:
                 self._ensure_daemon()
@@ -86,8 +92,9 @@ class ClickGate:
                 )
                 click.echo(response.data.get("text", ""))
 
-        vekna.add_command(daemon)
-        vekna.add_command(notify)
-        vekna.add_command(status_bar)
+        tmux.add_command(daemon)
+        tmux.add_command(notify)
+        tmux.add_command(status_bar)
+        vekna.add_command(tmux)
 
         return vekna

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -14,6 +14,18 @@ def _clean_tmux_env(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.usefixtures("_clean_tmux_env")
 class TestVekna:
     @staticmethod
+    def test_bare_vekna_prints_help_listing_tmux() -> None:
+        runner = CliRunner()
+
+        result = runner.invoke(init_command())
+
+        assert result.exit_code == 0
+        assert "tmux" in result.output
+
+
+@pytest.mark.usefixtures("_clean_tmux_env")
+class TestTmuxAttach:
+    @staticmethod
     @patch("vekna.mills.notify.NotifyClientMill.request", new_callable=AsyncMock)
     @patch("vekna.inits.cli.ensure_daemon_running")
     @patch("os.execvp")
@@ -25,7 +37,7 @@ class TestVekna:
         request_mock.return_value = response
         runner = CliRunner()
 
-        result = runner.invoke(init_command())
+        result = runner.invoke(init_command(), ["tmux"])
 
         assert result.exit_code == 0
         ensure_mock.assert_called_once_with()
@@ -46,7 +58,7 @@ class TestVekna:
         request_mock.return_value = response
         runner = CliRunner()
 
-        runner.invoke(init_command())
+        runner.invoke(init_command(), ["tmux"])
 
         ensure_mock.assert_called_once_with()
         execvp_mock.assert_called_once()
@@ -63,7 +75,7 @@ class TestDaemon:
     def test_invokes_server_mill_run(run_mock) -> None:
         runner = CliRunner()
 
-        result = runner.invoke(init_command(), ["daemon"])
+        result = runner.invoke(init_command(), ["tmux", "daemon"])
 
         assert result.exit_code == 0
         run_mock.assert_called_once_with()
@@ -80,7 +92,8 @@ class TestNotify:
         runner = CliRunner()
 
         result = runner.invoke(
-            init_command(), ["notify", "--app", "claude", "--hook", "Notification"]
+            init_command(),
+            ["tmux", "notify", "--app", "claude", "--hook", "Notification"],
         )
 
         assert result.exit_code == 0
@@ -98,7 +111,7 @@ class TestNotify:
 
         result = runner.invoke(
             init_command(),
-            ["notify", "--app", "claude", "--hook", "Notification"],
+            ["tmux", "notify", "--app", "claude", "--hook", "Notification"],
             input='{"title": "done"}',
         )
 
@@ -116,7 +129,8 @@ class TestNotify:
         runner = CliRunner()
 
         result = runner.invoke(
-            init_command(), ["notify", "--app", "claude", "--hook", "Notification"]
+            init_command(),
+            ["tmux", "notify", "--app", "claude", "--hook", "Notification"],
         )
 
         assert result.exit_code != 0
@@ -129,7 +143,9 @@ class TestNotify:
         monkeypatch.setenv("TMUX_PANE", "%7")
         runner = CliRunner()
 
-        result = runner.invoke(init_command(), ["notify", "--hook", "Notification"])
+        result = runner.invoke(
+            init_command(), ["tmux", "notify", "--hook", "Notification"]
+        )
 
         assert result.exit_code != 0
         notify_mock.assert_not_called()
@@ -140,7 +156,7 @@ class TestNotify:
         monkeypatch.setenv("TMUX_PANE", "%7")
         runner = CliRunner()
 
-        result = runner.invoke(init_command(), ["notify", "--app", "claude"])
+        result = runner.invoke(init_command(), ["tmux", "notify", "--app", "claude"])
 
         assert result.exit_code != 0
         notify_mock.assert_not_called()
@@ -156,7 +172,7 @@ class TestStatusBar:
         request_mock.return_value = response
         runner = CliRunner()
 
-        result = runner.invoke(init_command(), ["status-bar"])
+        result = runner.invoke(init_command(), ["tmux", "status-bar"])
 
         assert result.exit_code == 0
         assert "work(2)" in result.output
@@ -169,7 +185,7 @@ class TestStatusBar:
         request_mock.return_value = response
         runner = CliRunner()
 
-        runner.invoke(init_command(), ["status-bar"])
+        runner.invoke(init_command(), ["tmux", "status-bar"])
 
         call_event = request_mock.call_args[0][0]
         assert call_event.app == "vekna"
@@ -183,7 +199,7 @@ class TestStatusBar:
     def test_exits_silently_if_daemon_not_running(request_mock) -> None:
         runner = CliRunner()
 
-        result = runner.invoke(init_command(), ["status-bar"])
+        result = runner.invoke(init_command(), ["tmux", "status-bar"])
 
         request_mock.assert_called_once()
         assert result.exit_code == 0


### PR DESCRIPTION
Free the top-level `vekna` command for the upcoming rituals overseer. Existing tmux focus-switcher behaviour moves one level deeper: `vekna` → `vekna tmux`, plus `tmux daemon` / `tmux notify` / `tmux status-bar`. Bare `vekna` prints help. Bundled tmux.conf, README, CHANGELOG, and the Claude Code hook guidance updated to match.